### PR TITLE
Update omniauth-oauth2 dependency to permit latest Faraday.

### DIFF
--- a/omniauth-createsend.gemspec
+++ b/omniauth-createsend.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.licenses      = ["MIT"]
 
-  s.add_runtime_dependency "omniauth-oauth2", "~> 1.1"
+  s.add_runtime_dependency "omniauth-oauth2", "~> 1.6.0"
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "rack-test", "~> 0.6"
   s.add_development_dependency "webmock", "~> 1.0"


### PR DESCRIPTION
When I tried to update Faraday, I got this dependency chain:

```
omniauth-createsend was resolved to 1.0.3, which depends on
  omniauth-oauth2 (~> 1.1) was resolved to 1.4.0, which depends on
      oauth2 (~> 1.0) was resolved to 1.0.0, which depends on
	faraday (< 0.10, >= 0.8)
```

Using omniauth-oauth2 1.6.x brings in oauth2 1.4.x, which caps faraday
at 0.16.0 (which permits the latest version).